### PR TITLE
Fix event loop blocking in work endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,8 @@
+import asyncio
+import logging
 import os
 import random
 import time
-import logging
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException
@@ -118,8 +119,8 @@ async def work(ms: Optional[int] = 200):
     with tracer.start_as_current_span("compute") as span:
         span.set_attribute("endpoint", "/work")
         span.set_attribute("work.ms", ms)
-        # simulate work
-        time.sleep(max(0, ms) / 1000.0)
+        # simulate work without blocking the event loop
+        await asyncio.sleep(max(0, ms) / 1000.0)
         if random.random() < 0.05:
             log.warning(
                 "intermittent issue observed",

--- a/app/main.py
+++ b/app/main.py
@@ -103,18 +103,6 @@ async def root():
     return JSONResponse(body)
 
 
-def _normalize_delay_ms(ms: Optional[int]) -> int:
-    """Validate the requested work duration and return milliseconds."""
-
-    if ms is None:
-        return 200
-
-    if ms < 0:
-        raise HTTPException(status_code=400, detail="ms must be non-negative")
-
-    return ms
-
-
 @app.get("/work")
 async def work(ms: Optional[int] = 200):
     start = time.perf_counter()
@@ -167,3 +155,15 @@ async def error():
             extra={"trace_id": trace.format_trace_id(span.get_span_context().trace_id)},
         )
         raise HTTPException(status_code=500, detail="boom")
+
+
+def _normalize_delay_ms(ms: Optional[int]) -> int:
+    """Validate the requested work duration and return milliseconds."""
+
+    if ms is None:
+        return 200
+
+    if ms < 0:
+        raise HTTPException(status_code=400, detail="ms must be non-negative")
+
+    return ms

--- a/app/main.py
+++ b/app/main.py
@@ -103,6 +103,18 @@ async def root():
     return JSONResponse(body)
 
 
+def _normalize_delay_ms(ms: Optional[int]) -> int:
+    """Validate the requested work duration and return milliseconds."""
+
+    if ms is None:
+        return 200
+
+    if ms < 0:
+        raise HTTPException(status_code=400, detail="ms must be non-negative")
+
+    return ms
+
+
 @app.get("/work")
 async def work(ms: Optional[int] = 200):
     start = time.perf_counter()
@@ -116,11 +128,12 @@ async def work(ms: Optional[int] = 200):
             "is_valid": ctx.is_valid,
         },
     )
+    delay_ms = _normalize_delay_ms(ms)
     with tracer.start_as_current_span("compute") as span:
         span.set_attribute("endpoint", "/work")
-        span.set_attribute("work.ms", ms)
+        span.set_attribute("work.ms", delay_ms)
         # simulate work without blocking the event loop
-        await asyncio.sleep(max(0, ms) / 1000.0)
+        await asyncio.sleep(delay_ms / 1000.0)
         if random.random() < 0.05:
             log.warning(
                 "intermittent issue observed",
@@ -131,7 +144,7 @@ async def work(ms: Optional[int] = 200):
     elapsed_ms = (time.perf_counter() - start) * 1000
     req_counter.add(1, {"route": "/work"})
     latency_hist.record(elapsed_ms, {"route": "/work"})
-    return {"ok": True, "work_ms": ms, "latency_ms": round(elapsed_ms, 2)}
+    return {"ok": True, "work_ms": delay_ms, "latency_ms": round(elapsed_ms, 2)}
 
 
 @app.get("/error")


### PR DESCRIPTION
## Summary
- use asyncio.sleep in the /work handler to avoid blocking the event loop
- ensure imports include asyncio to support the non-blocking sleep

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68ce2ec0f4c88323953c513d7aff796b