### PR TITLE
Add k8s integration automation and docs (#13)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,15 +37,15 @@ jobs:
 
       - name: Build demo images for local overlay
         run: |
-          docker build -t space-app:latest app
-          docker build -t loadgen:latest loadgen
-          kind load docker-image space-app:latest --name otel-lgtm
-          kind load docker-image loadgen:latest --name otel-lgtm
+          docker build -t localhost/space-app:latest app
+          docker build -t localhost/loadgen:latest loadgen
+          kind load docker-image localhost/space-app:latest --name otel-lgtm
+          kind load docker-image localhost/loadgen:latest --name otel-lgtm
 
       - name: Build integration test image
         run: |
-          docker build -t integration-tests:latest -f tests/integration/Dockerfile .
-          kind load docker-image integration-tests:latest --name otel-lgtm
+          docker build -t localhost/integration-tests:latest -f tests/integration/Dockerfile .
+          kind load docker-image localhost/integration-tests:latest --name otel-lgtm
 
       - name: Deploy observability stack to kind
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose.integration.yml down -v
           exit $status
 
-  k8s-smoke:
+  k8s-integration:
     runs-on: ubuntu-latest
     needs: integration
     steps:
@@ -42,6 +42,11 @@ jobs:
           kind load docker-image space-app:latest --name otel-lgtm
           kind load docker-image loadgen:latest --name otel-lgtm
 
+      - name: Build integration test image
+        run: |
+          docker build -t integration-tests:latest -f tests/integration/Dockerfile .
+          kind load docker-image integration-tests:latest --name otel-lgtm
+
       - name: Deploy observability stack to kind
         run: |
           kubectl kustomize deploy/k8s/base >/dev/null
@@ -52,22 +57,18 @@ jobs:
         run: |
           kubectl wait --namespace observability --for=condition=Available deployment --all --timeout=5m
 
-      - name: Smoke test FastAPI service
+      - name: Run Kubernetes integration tests
         run: |
           set -euo pipefail
-          kubectl run curl --namespace observability --restart=Never --image=curlimages/curl:8.5.0 --command -- curl -fsS http://space-app:8000/ || {
-            kubectl logs --namespace observability deploy/space-app || true
-            kubectl logs --namespace observability deploy/otelcol || true
-            exit 1
-          }
-          kubectl delete pod curl --namespace observability --wait=true
+          WAIT_TIMEOUT=15m ./scripts/run_k8s_integration_tests.sh
 
       - name: Collect diagnostics on failure
         if: failure()
         run: |
           kubectl get pods -n observability
           kubectl describe pods -n observability
-          kubectl logs -n observability deploy/otelcol
+          kubectl logs -n observability deploy/otelcol || true
+          kubectl logs -n observability job/integration-tests || true
 
       - name: Tear down stack
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ k8s-apply-production:
 .PHONY: k8s-delete-production
 k8s-delete-production:
 	$(KUBECTL) delete -k deploy/k8s/overlays/production
+
+.PHONY: k8s-integration-test
+k8s-integration-test:
+	./scripts/run_k8s_integration_tests.sh

--- a/deploy/k8s/base/config/tempo/tempo-config.yml
+++ b/deploy/k8s/base/config/tempo/tempo-config.yml
@@ -9,9 +9,9 @@ distributor:
     otlp: # Receives OTLP traces from collectors/agents (prefer grpc for high volume; secure endpoints in prod)
       protocols:
         grpc:
-          endpoint: "tempo:4317" # default gRPC OTLP port; use TLS/auth in production
+          endpoint: "0.0.0.0:4317" # bind to pod IP so it works with both Kubernetes Services and compose networks
         http:
-          endpoint: "tempo:4318" # HTTP OTLP endpoint; disable if not used to reduce attack surface
+          endpoint: "0.0.0.0:4318" # ditto for HTTP OTLP; keep accessible within the cluster only
 
 storage:
   trace:

--- a/deploy/k8s/base/grafana.yaml
+++ b/deploy/k8s/base/grafana.yaml
@@ -74,6 +74,13 @@ spec:
         - name: grafana-provisioning
           configMap:
             name: grafana-provisioning
+            items:
+              - key: alerts.yml
+                path: alerting/alerts.yml
+              - key: dashboards.yml
+                path: dashboards/dashboards.yml
+              - key: datasources.yml
+                path: datasources/datasources.yml
         - name: grafana-dashboards
           configMap:
             name: grafana-dashboards

--- a/deploy/k8s/base/tempo.yaml
+++ b/deploy/k8s/base/tempo.yaml
@@ -41,6 +41,10 @@ spec:
           ports:
             - containerPort: 3200
               name: http
+            - containerPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              name: otlp-http
           volumeMounts:
             - name: tempo-config
               mountPath: /etc/tempo/config
@@ -71,3 +75,9 @@ spec:
     - name: http
       port: 3200
       targetPort: http
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317

--- a/deploy/k8s/overlays/local/kustomization.yaml
+++ b/deploy/k8s/overlays/local/kustomization.yaml
@@ -8,10 +8,10 @@ resources:
 
 images:
   - name: ghcr.io/hyzhak/otel-lgtm-mvp/space-app
-    newName: space-app
+    newName: localhost/space-app
     newTag: latest
   - name: ghcr.io/hyzhak/otel-lgtm-mvp/loadgen
-    newName: loadgen
+    newName: localhost/loadgen
     newTag: latest
 
 patches:

--- a/deploy/k8s/tests/integration-tests-job.yaml
+++ b/deploy/k8s/tests/integration-tests-job.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: integration-tests
+  labels:
+    app.kubernetes.io/name: integration-tests
+    app.kubernetes.io/part-of: otel-lgtm-mvp
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: integration-tests
+        app.kubernetes.io/part-of: otel-lgtm-mvp
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: integration-tests
+          image: localhost/integration-tests:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: STACK_READY_TIMEOUT
+              value: "300"
+            - name: OBS_WAIT_TIMEOUT
+              value: "240"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi

--- a/deploy/k8s/tests/kustomization.yaml
+++ b/deploy/k8s/tests/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: observability
+
+resources:
+  - integration-tests-job.yaml

--- a/docs/insights/k8s-integration-lessons.md
+++ b/docs/insights/k8s-integration-lessons.md
@@ -1,0 +1,26 @@
+# Kubernetes Integration Lessons Learned
+
+## Grafana provisioning paths
+- **Issue:** Grafana started without any Prometheus, Loki, or Tempo data sources even though provisioning ConfigMaps were applied.
+- **Resolution:** Explicitly mapped each provisioning file (`datasources.yml`, `dashboards.yml`, `alerts.yml`) into Grafana's expected subdirectories under `/etc/grafana/provisioning`. This mirrors the docker-compose volume layout and unblocks automatic data-source creation.
+- **Takeaway:** When bridging compose-to-Kubernetes configs, verify mount paths against upstream defaults—Grafana silently skips provisioning if the directory structure is off.
+
+## Tempo OTLP endpoints
+- **Issue:** The Tempo distributor only listened on the service DNS name (`tempo:4317/4318`), which fails inside kind/Podman where the pod IP differs from the service hostname.
+- **Resolution:** Bound the OTLP gRPC and HTTP listeners to `0.0.0.0` and exposed ports 4317/4318 on the Service. Now the OpenTelemetry Collector and integration tests can reach Tempo regardless of networking backend.
+- **Takeaway:** Prefer binding to the pod IP (`0.0.0.0`) inside clusters unless a sidecar proxy injects routing—service hostnames are resolved by clients, not by the server.
+
+## Self-contained integration test image
+- **Issue:** The previous integration-test container assumed docker-compose volume mounts for test sources, so the Kubernetes Job could not run the suite.
+- **Resolution:** Bundled `pytest.ini`, `tests/__init__.py`, and `tests/integration/` into the image, matching how the compose build works.
+- **Takeaway:** Keep test containers hermetic. If a workflow mounts code at runtime, replicate that structure when reusing the image in other orchestrators.
+
+## Local image names for kind
+- **Issue:** kind requires images to be tagged `localhost/<name>` when loaded via `kind load docker-image`; our overlay still referenced upstream `ghcr.io` names, triggering pull failures.
+- **Resolution:** Pointed the local overlay at `localhost/` tags and updated helper scripts to build/tag/load with that convention.
+- **Takeaway:** Align overlay image names with the cluster loader tooling to avoid hidden pullFromRegistry steps, especially when iterating locally.
+
+## Automation scripts
+- **Issue:** Validating compose vs. Kubernetes flows manually was slow and error prone.
+- **Resolution:** Added one-command bash helpers for compose tests, Kubernetes tests, and dev stack bootstrap. Each script supports overrides (`DOCKER_CONFIG_DIR`, timeouts, keep-flags) so they work on macOS and Ubuntu alike.
+- **Takeaway:** Invest in repeatable scripts early; they surface configuration regressions (e.g., missing Tempo ports) before they hit CI or teammates.

--- a/scripts/run_compose_integration_tests.sh
+++ b/scripts/run_compose_integration_tests.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCKER_CONFIG_DIR=${DOCKER_CONFIG_DIR:-}
+
+if [[ -n "${DOCKER_CONFIG_DIR}" ]]; then
+  export DOCKER_CONFIG="${DOCKER_CONFIG_DIR}"
+fi
+
+if [[ -n "${COMPOSE:-}" ]]; then
+  IFS=' ' read -r -a COMPOSE_CMD <<< "${COMPOSE}"
+else
+  if docker compose version >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker compose)
+  elif command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE_CMD=(docker-compose)
+  else
+    echo "[error] neither 'docker compose' nor 'docker-compose' is available" >&2
+    exit 1
+  fi
+fi
+
+COMPOSE_ARGS=(-f docker-compose.yml -f docker-compose.integration.yml)
+
+cleanup() {
+  "${COMPOSE_CMD[@]}" "${COMPOSE_ARGS[@]}" down -v >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+"${COMPOSE_CMD[@]}" "${COMPOSE_ARGS[@]}" up --build --exit-code-from integration-tests integration-tests

--- a/scripts/run_k8s_integration_tests.sh
+++ b/scripts/run_k8s_integration_tests.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECTL=${KUBECTL:-kubectl}
+KUSTOMIZE_PATH=${KUSTOMIZE_PATH:-deploy/k8s/tests}
+JOB_NAME=${JOB_NAME:-integration-tests}
+NAMESPACE=${NAMESPACE:-observability}
+WAIT_TIMEOUT=${WAIT_TIMEOUT:-10m}
+KEEP_RESOURCES=${KEEP_RESOURCES:-0}
+
+cleanup() {
+  if [[ "$KEEP_RESOURCES" != "1" ]]; then
+    ${KUBECTL} delete -k "${KUSTOMIZE_PATH}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+get_latest_pod() {
+  ${KUBECTL} get pods \
+    --namespace "${NAMESPACE}" \
+    --selector "job-name=${JOB_NAME}" \
+    -o jsonpath='{range .items[*]}{.metadata.creationTimestamp}{"\t"}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+    | sort \
+    | awk 'END {print $2}'
+}
+
+${KUBECTL} delete job "${JOB_NAME}" --namespace "${NAMESPACE}" --ignore-not-found >/dev/null 2>&1 || true
+${KUBECTL} apply -k "${KUSTOMIZE_PATH}"
+
+wait_cmd=("${KUBECTL}" wait --namespace "${NAMESPACE}" --for=condition=complete "job/${JOB_NAME}" --timeout="${WAIT_TIMEOUT}")
+if ! "${wait_cmd[@]}"; then
+  echo "[error] integration test job did not complete successfully" >&2
+  ${KUBECTL} get pods --namespace "${NAMESPACE}" --selector "job-name=${JOB_NAME}" || true
+  ${KUBECTL} describe job "${JOB_NAME}" --namespace "${NAMESPACE}" || true
+  latest_pod=$(get_latest_pod || true)
+  if [[ -n "${latest_pod:-}" ]]; then
+    echo "--- logs from ${latest_pod} ---" >&2
+    ${KUBECTL} logs "${latest_pod}" --namespace "${NAMESPACE}" || true
+  fi
+  KEEP_RESOURCES=1
+  exit 1
+fi
+
+latest_pod=$(get_latest_pod || true)
+if [[ -z "${latest_pod:-}" ]]; then
+  echo "[warn] job completed but no pod was found for ${JOB_NAME}" >&2
+else
+  echo "--- logs from ${latest_pod} ---"
+  ${KUBECTL} logs "${latest_pod}" --namespace "${NAMESPACE}"
+fi

--- a/scripts/run_k8s_integration_tests_full.sh
+++ b/scripts/run_k8s_integration_tests_full.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KIND_BIN=${KIND:-kind}
+KUBECTL_BIN=${KUBECTL:-kubectl}
+DOCKER_BIN=${DOCKER:-docker}
+CLUSTER_NAME=${CLUSTER_NAME:-otel-lgtm}
+KEEP_CLUSTER=${KEEP_CLUSTER:-0}
+KEEP_STACK=${KEEP_STACK:-0}
+STACK_NAMESPACE=${NAMESPACE:-observability}
+OVERLAY_PATH=${OVERLAY_PATH:-deploy/k8s/overlays/local}
+WAIT_DEPLOY_TIMEOUT=${WAIT_DEPLOY_TIMEOUT:-5m}
+WAIT_JOB_TIMEOUT=${WAIT_JOB_TIMEOUT:-15m}
+DOCKER_CONFIG_DIR=${DOCKER_CONFIG_DIR:-}
+
+if [[ -n "${DOCKER_CONFIG_DIR}" ]]; then
+  export DOCKER_CONFIG="${DOCKER_CONFIG_DIR}"
+fi
+
+created_cluster=0
+overlay_applied=0
+
+cleanup() {
+  if [[ "${overlay_applied}" == "1" ]] && [[ "${KEEP_STACK}" != "1" ]]; then
+    ${KUBECTL_BIN} delete -k "${OVERLAY_PATH}" >/dev/null 2>&1 || true
+  fi
+
+  if [[ "${created_cluster}" == "1" ]] && [[ "${KEEP_CLUSTER}" != "1" ]]; then
+    ${KIND_BIN} delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+if ! ${KIND_BIN} get clusters 2>/dev/null | grep -Fxq "${CLUSTER_NAME}"; then
+  ${KIND_BIN} create cluster --name "${CLUSTER_NAME}" --wait 2m
+  created_cluster=1
+else
+  echo "[info] kind cluster ${CLUSTER_NAME} already exists; reusing it"
+fi
+
+${DOCKER_BIN} build -t localhost/space-app:latest app
+${DOCKER_BIN} build -t localhost/loadgen:latest loadgen
+${DOCKER_BIN} build -t localhost/integration-tests:latest -f tests/integration/Dockerfile .
+
+${KIND_BIN} load docker-image localhost/space-app:latest --name "${CLUSTER_NAME}"
+${KIND_BIN} load docker-image localhost/loadgen:latest --name "${CLUSTER_NAME}"
+${KIND_BIN} load docker-image localhost/integration-tests:latest --name "${CLUSTER_NAME}"
+
+${KUBECTL_BIN} apply -k "${OVERLAY_PATH}"
+overlay_applied=1
+
+${KUBECTL_BIN} wait --namespace "${STACK_NAMESPACE}" --for=condition=Available deployment --all --timeout="${WAIT_DEPLOY_TIMEOUT}"
+
+WAIT_TIMEOUT="${WAIT_JOB_TIMEOUT}" ./scripts/run_k8s_integration_tests.sh
+
+if [[ "${KEEP_STACK}" != "1" ]]; then
+  ${KUBECTL_BIN} delete -k "${OVERLAY_PATH}"
+  overlay_applied=0
+fi
+
+if [[ "${created_cluster}" == "1" ]] && [[ "${KEEP_CLUSTER}" != "1" ]]; then
+  ${KIND_BIN} delete cluster --name "${CLUSTER_NAME}"
+  created_cluster=0
+fi

--- a/scripts/start_k8s_dev_stack.sh
+++ b/scripts/start_k8s_dev_stack.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KIND_BIN=${KIND:-kind}
+KUBECTL_BIN=${KUBECTL:-kubectl}
+DOCKER_BIN=${DOCKER:-docker}
+CLUSTER_NAME=${CLUSTER_NAME:-otel-lgtm-dev}
+OVERLAY_PATH=${OVERLAY_PATH:-deploy/k8s/overlays/local}
+STACK_NAMESPACE=${NAMESPACE:-observability}
+WAIT_DEPLOY_TIMEOUT=${WAIT_DEPLOY_TIMEOUT:-5m}
+SKIP_BUILD=${SKIP_BUILD:-0}
+SKIP_LOAD=${SKIP_LOAD:-0}
+RESET_STACK=${RESET_STACK:-0}
+DOCKER_CONFIG_DIR=${DOCKER_CONFIG_DIR:-}
+KUBECONFIG_PATH=${KUBECONFIG_PATH:-}
+
+if [[ -n "${DOCKER_CONFIG_DIR}" ]]; then
+  export DOCKER_CONFIG="${DOCKER_CONFIG_DIR}"
+fi
+
+if [[ -n "${KUBECONFIG_PATH}" ]]; then
+  mkdir -p "$(dirname "${KUBECONFIG_PATH}")"
+  export KUBECONFIG="${KUBECONFIG_PATH}"
+fi
+
+ensure_context() {
+  if ! ${KIND_BIN} get clusters 2>/dev/null | grep -Fxq "${CLUSTER_NAME}"; then
+    echo "[info] creating kind cluster ${CLUSTER_NAME}"
+    ${KIND_BIN} create cluster --name "${CLUSTER_NAME}" --wait 2m
+  else
+    echo "[info] reusing existing kind cluster ${CLUSTER_NAME}"
+  fi
+
+  ${KIND_BIN} export kubeconfig --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+  ${KUBECTL_BIN} config use-context "kind-${CLUSTER_NAME}" >/dev/null 2>&1 || true
+}
+
+build_images() {
+  if [[ "${SKIP_BUILD}" == "1" ]]; then
+    echo "[info] skipping image build"
+    return
+  fi
+
+  ${DOCKER_BIN} build -t localhost/space-app:latest app
+  ${DOCKER_BIN} build -t localhost/loadgen:latest loadgen
+  ${DOCKER_BIN} build -t localhost/integration-tests:latest -f tests/integration/Dockerfile .
+}
+
+load_images() {
+  if [[ "${SKIP_LOAD}" == "1" ]]; then
+    echo "[info] skipping kind image load"
+    return
+  fi
+
+  ${KIND_BIN} load docker-image localhost/space-app:latest --name "${CLUSTER_NAME}"
+  ${KIND_BIN} load docker-image localhost/loadgen:latest --name "${CLUSTER_NAME}"
+  ${KIND_BIN} load docker-image localhost/integration-tests:latest --name "${CLUSTER_NAME}"
+}
+
+deploy_stack() {
+  if [[ "${RESET_STACK}" == "1" ]]; then
+    echo "[info] removing existing deployment resources"
+    ${KUBECTL_BIN} delete -k "${OVERLAY_PATH}" >/dev/null 2>&1 || true
+  fi
+
+  ${KUBECTL_BIN} apply -k "${OVERLAY_PATH}"
+
+  ${KUBECTL_BIN} wait \
+    --namespace "${STACK_NAMESPACE}" \
+    --for=condition=Available deployment --all \
+    --timeout="${WAIT_DEPLOY_TIMEOUT}"
+}
+
+summarise_access() {
+  echo
+  ${KUBECTL_BIN} get pods -n "${STACK_NAMESPACE}"
+  ${KUBECTL_BIN} get svc -n "${STACK_NAMESPACE}"
+
+  local active_kubeconfig="${KUBECONFIG:-$(printf '%s/.kube/config' "$HOME")}" 
+
+  cat <<MSG
+
+Stack is ready.
+- Port-forward the FastAPI app:   kubectl port-forward -n ${STACK_NAMESPACE} svc/space-app 8000:8000
+- Port-forward Grafana dashboards: kubectl port-forward -n ${STACK_NAMESPACE} svc/grafana 3000:3000
+
+When finished, tear down the stack with:
+  kubectl delete -k deploy/k8s/overlays/local
+and optionally delete the kind cluster with: kind delete cluster --name ${CLUSTER_NAME}
+
+Active kubeconfig: ${active_kubeconfig}
+If you need to use it in a new shell run: export KUBECONFIG=${active_kubeconfig}
+MSG
+}
+
+ensure_context
+build_images
+load_images
+deploy_stack
+summarise_access

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -5,4 +5,9 @@ WORKDIR /workspace
 COPY tests/requirements-dev.txt /tmp/requirements-dev.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-dev.txt
 
+# Bundle the integration test suite so the image can run standalone inside Kubernetes clusters
+COPY pytest.ini ./
+COPY tests/__init__.py ./tests/__init__.py
+COPY tests/integration ./tests/integration
+
 CMD ["python", "-m", "pytest", "tests/integration", "-vv"]


### PR DESCRIPTION
- add integration tests for k8s configuration
- add automation scripts to run docker compose and Kubernetes integration tests on macOS/Ubuntu
- fix Grafana data sources
- document the workflows and lessons learned

ref: #13 