### PR TITLE
Add architecture documentation and replication playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,38 +13,15 @@ The stack includes:
 
 The core application is a FastAPI service that generates sample telemetry data, simulating real-world observability scenarios.
 
-## High-Level Design Document
+## Documentation
 
-### Architecture Overview
+- [High-Level Design](docs/high-level-design.md) – Architecture, deployment views, and sequence diagrams that explain how telemetry moves through the stack.
+- [Lessons Learned and Replication Guide](docs/lessons-learned.md) – Step-by-step playbook for recreating the MVP architecture and avoiding common pitfalls.
+- [Kubernetes Manifests Deep Dive](docs/k8s-manifests.md) – Reference for every manifest, configuration file, and overlay.
 
-The system follows a microservices architecture with the following components:
+## Architecture Summary
 
-- **Application (FastAPI)**: The main service instrumented with OpenTelemetry for automatic generation of traces, metrics, and logs
-- **OpenTelemetry Collector**: Receives OTLP (OpenTelemetry Protocol) data from the application and routes it to appropriate backends
-- **Backends**:
-  - **Prometheus**: Stores and serves metrics data
-  - **Tempo**: Stores and queries distributed traces
-  - **Loki**: Aggregates and indexes log data
-- **Visualization**: Grafana provides unified dashboards for all telemetry data
-- **Load Generator**: A separate service that simulates traffic to the FastAPI application
-
-### Data Flow
-
-```mermaid
-flowchart LR
-    A[Application<br/>FastAPI] --> B[OpenTelemetry<br/>Collector]
-    B --> C[Prometheus<br/>Metrics]
-    B --> D[Tempo<br/>Traces]
-    B --> E[Loki<br/>Logs]
-    C --> F[Grafana<br/>Visualization]
-    D --> F
-    E --> F
-```
-
-1. The FastAPI application generates telemetry data through OpenTelemetry instrumentation
-2. Data is sent via OTLP to the OpenTelemetry Collector
-3. The Collector processes and routes data to respective backends
-4. Grafana queries all backends to create comprehensive dashboards
+The MVP instruments a FastAPI service (`app/main.py`) with OpenTelemetry, exports traces, metrics, and logs via OTLP, and funnels them through an OpenTelemetry Collector that distributes each signal type to the LGTM backends (Loki, Grafana Tempo, and Prometheus). Grafana aggregates the data sources so developers can correlate logs, metrics, and traces in a single dashboard experience, while a lightweight load generator (`loadgen/loadgen.py`) keeps the telemetry pipeline active for demos and tests.【F:app/main.py†L24-L118】【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L1-L38】【F:loadgen/loadgen.py†L1-L25】
 
 ## Steps to Run Application
 

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -1,0 +1,181 @@
+# High-Level Design
+
+This document captures the target architecture for the OpenTelemetry MVP stack and explains how the components collaborate to deliver an end-to-end observability experience across traces, metrics, and logs.
+
+## System Context
+
+The solution centers on an instrumented FastAPI application that emits OpenTelemetry signals. The OpenTelemetry Collector acts as a control point, accepting traffic from the app and forwarding it to dedicated backends—Prometheus, Tempo, and Loki—while Grafana offers a unified visualization interface.
+
+```mermaid
+%%{init: {"theme": "neutral"}}%%
+usecaseDiagram
+  actor User as Developer
+  actor "Synthetic Client" as LoadGen
+  rectangle "Observability MVP" {
+    (Inspect dashboards) as Inspect
+    (Trigger application endpoints) as Invoke
+    (Generate background traffic) as Traffic
+    (Collect OTLP signals) as Collect
+    (Persist metrics) as Metrics
+    (Persist traces) as Traces
+    (Persist logs) as Logs
+    (Render dashboards) as Visualize
+  }
+  Developer --> Inspect
+  Developer --> Invoke
+  LoadGen --> Traffic
+  Invoke --> Collect
+  Traffic --> Collect
+  Collect --> Metrics
+  Collect --> Traces
+  Collect --> Logs
+  Metrics --> Visualize
+  Traces --> Visualize
+  Logs --> Visualize
+  Visualize --> Inspect
+```
+
+*Figure 1 – Use cases showing how developers and the synthetic load generator interact with the observability platform.*
+
+## Logical Architecture
+
+The system is composed of loosely coupled services, each responsible for a single aspect of the observability workflow. The instrumentation in `app/main.py` automatically produces spans, metrics, and logs. The OpenTelemetry Collector defined in `deploy/k8s/base/config/otel-collector/otelcol-config.yml` fans those signals out to the LGTM stack, and Grafana serves as the access point for exploration.
+
+```mermaid
+%%{init: {"theme": "neutral"}}%%
+flowchart TB
+  subgraph Client
+    cli[Developer]
+    loadgen[Load Generator]
+  end
+  subgraph AppTier[FastAPI Application]
+    app[space-app]
+  end
+  subgraph Collector[OpenTelemetry Collector]
+    otel[OTLP Receivers\n+ processors]
+  end
+  subgraph Observability[Loki-Tempo-Prometheus]
+    loki[Loki\n(log storage)]
+    tempo[Tempo\n(trace storage)]
+    prom[Prometheus\n(metrics TSDB)]
+  end
+  grafana[ Grafana ]
+
+  cli -->|HTTP| app
+  loadgen -->|Synthetic requests| app
+  app -->|OTLP/gRPC + HTTP| otel
+  otel -->|Metrics| prom
+  otel -->|Traces| tempo
+  otel -->|Logs| loki
+  prom --> grafana
+  tempo --> grafana
+  loki --> grafana
+```
+
+*Figure 2 – Component diagram summarizing the logical responsibilities and communication paths.*
+
+## Deployment View
+
+The deployment manifests in `deploy/k8s/base/*.yaml` and the Docker Compose definitions mirror one another, ensuring parity between local and cluster environments. Both topologies rely on shared configuration mounted from `deploy/k8s/base/config`. Persistent components (Loki and Prometheus) additionally require volumes in production environments to safeguard state.
+
+```mermaid
+%%{init: {"theme": "neutral"}}%%
+flowchart LR
+  subgraph Local
+    compose[docker-compose.yml]
+    app_svc[(FastAPI Service)]
+    collector_svc[(OTel Collector)]
+    lgtm_stack[(Loki/Tempo/Prometheus)]
+    grafana_svc[(Grafana)]
+  end
+  subgraph Cluster
+    kustomize[deploy/k8s/overlays]
+    k8s_app[(Deployment: space-app)]
+    k8s_collector[(Deployment: otelcol)]
+    k8s_lgtm[(StatefulSets/Deployments)]
+    k8s_grafana[(Deployment: grafana)]
+  end
+
+  compose --> app_svc
+  compose --> collector_svc
+  compose --> lgtm_stack
+  compose --> grafana_svc
+
+  kustomize --> k8s_app
+  kustomize --> k8s_collector
+  kustomize --> k8s_lgtm
+  kustomize --> k8s_grafana
+
+  classDef infra fill:#f2f2f2,stroke:#999,stroke-width:1px;
+  class compose,kustomize infra;
+```
+
+*Figure 3 – Deployment parity between local Compose workflows and Kubernetes overlays.*
+
+## Request Lifecycle
+
+From an observability perspective, the most critical workflow involves a user request entering the system, traversing the collector, and becoming visible in dashboards. The following sequence diagram illustrates the flow for the `/work` endpoint, including metrics and logs captured along the way.
+
+```mermaid
+%%{init: {"theme": "neutral"}}%%
+sequenceDiagram
+  participant Client
+  participant FastAPI as FastAPI app
+  participant OTel as OTel Collector
+  participant Prom as Prometheus
+  participant Tempo
+  participant Loki
+
+  Client->>FastAPI: GET /work?ms=200
+  activate FastAPI
+  FastAPI-->>FastAPI: Instrumentation creates span + metrics
+  FastAPI-->>FastAPI: Log current span context
+  FastAPI-->>FastAPI: Sleep to simulate work
+  FastAPI->>Client: 200 OK JSON payload
+  deactivate FastAPI
+  FastAPI->>OTel: Export OTLP traces/metrics/logs
+  OTel->>Prom: Push metrics endpoint scrape
+  OTel->>Tempo: Send traces via OTLP HTTP
+  OTel->>Loki: Send logs via OTLP HTTP
+  Prom-->>Grafana: Metrics available for dashboards
+  Tempo-->>Grafana: Traces available for dashboards
+  Loki-->>Grafana: Logs available for dashboards
+```
+
+*Figure 4 – Sequence diagram for an instrumented request showing telemetry propagation.*
+
+The instrumentation behavior and collector routing shown above are implemented in the FastAPI service and collector configuration files.【F:app/main.py†L21-L118】【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L1-L38】 The load generator continuously exercises the API, ensuring the telemetry pipeline remains active for validation.【F:loadgen/loadgen.py†L1-L25】
+
+## Data Management Considerations
+
+- **Metrics** – Prometheus scrapes the collector’s `/metrics` endpoint at `0.0.0.0:8889`, as configured in the collector manifest, and stores samples in its local time-series database.【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L20-L24】【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L37-L40】
+- **Traces** – Tempo accepts spans over OTLP HTTP, enabling Grafana Tempo data source queries without additional shims.【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L26-L32】
+- **Logs** – Loki ingests OTLP log payloads and indexes them for search, enabling trace-to-log correlations using shared trace IDs.【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L32-L38】【F:app/main.py†L73-L118】
+
+## Observability Features
+
+- Automatic FastAPI instrumentation via `FastAPIInstrumentor.instrument_app` ensures route spans are created without manual boilerplate.【F:app/main.py†L60-L64】
+- Structured logging includes trace and span IDs so Grafana Loki explorations can pivot between logs and traces.【F:app/main.py†L70-L118】
+- Custom metrics counters and histograms quantify request volume and latency per route, enabling SLO dashboards in Grafana.【F:app/main.py†L46-L59】【F:app/main.py†L86-L109】
+
+## Scalability and Extensibility
+
+- **Collector pipelines** can be extended with additional processors/exporters for other telemetry backends by editing `otelcol-config.yml`, keeping application code untouched.【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L1-L38】
+- **Deployment overlays** (`deploy/k8s/overlays/*`) allow environment-specific tuning—resource limits, ingress, storage classes—without diverging from the base templates.
+- **Load generation** via `loadgen/loadgen.py` offers a repeatable way to stress the stack and validate instrumentation during development or CI pipelines.【F:loadgen/loadgen.py†L1-L25】
+
+## Testing Strategy
+
+- Unit tests can target FastAPI route behavior (see `tests/`) while using the provided `docker-compose.integration.yml` or Kubernetes manifests for integration smoke tests.
+- To validate observability, run the load generator alongside the stack and confirm telemetry ingestion in Grafana dashboards, Loki log streams, and Tempo trace views.
+
+## Security and Operations
+
+- Grafana credentials and anonymous access are configurable via environment variables (`GF_*`), which should be hardened in production deployments.【F:README.md†L44-L85】
+- For shared clusters, replace placeholder secrets and configure persistent volumes for data-retaining services to avoid data loss across restarts.
+
+## Future Improvements
+
+- Introduce OpenTelemetry Collector tail-based sampling for trace volume management.
+- Automate dashboard provisioning via Grafana JSON board definitions in `deploy/k8s/base/config/grafana`.
+- Expand automated tests to verify telemetry content using the OTLP exporter test harness.

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -1,0 +1,78 @@
+# Lessons Learned and Replication Guide
+
+This document distills the key lessons from the OpenTelemetry LGTM MVP and outlines a reproducible playbook for building a similar observability stack. Each section highlights actionable steps, rationale, and references to configuration or code artifacts that can be reused.
+
+## 1. Start with Clear Telemetry Goals
+
+1. Identify the critical user journeys or API flows that must be observable. For this MVP, the `/`, `/work`, and `/error` endpoints represent healthy, latent, and failure scenarios.【F:app/main.py†L66-L118】
+2. Decide which signals (traces, metrics, logs) are necessary for each flow. Capturing all three provides correlation opportunities across the stack.
+3. Document desired dashboards or alerts early; they guide instrumentation granularity.
+
+## 2. Instrument the Application First
+
+1. Configure a unified OpenTelemetry `Resource` so every signal shares service metadata. This enables Grafana to filter and correlate telemetry across backends.【F:app/main.py†L24-L41】
+2. Initialize trace, metric, and log providers at application startup. Reuse OTLP exporters so the collector can act as the fan-out point.【F:app/main.py†L42-L118】
+3. Apply framework-specific auto-instrumentation (`FastAPIInstrumentor`) and add minimal manual spans or events to cover business logic hotspots.【F:app/main.py†L60-L105】
+4. Emit structured logs via the OpenTelemetry logging handler so span and trace IDs appear automatically in log records.【F:app/main.py†L70-L118】
+
+**Tip:** Keep instrumentation code close to request handlers to simplify onboarding for new contributors.
+
+## 3. Centralize Routing with an OpenTelemetry Collector
+
+1. Deploy a collector with both HTTP and gRPC OTLP receivers to accommodate varied client libraries.【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L1-L16】
+2. Add lightweight processors—`memory_limiter`, `batch`, and `resource`—to stabilize throughput and enforce consistent metadata.【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L10-L19】
+3. Configure exporters for each backend: Prometheus for metrics, Tempo for traces, and Loki for logs.【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L20-L38】
+4. Expose the Prometheus exporter endpoint so scrapers can pull metrics without direct app access.【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L20-L24】
+
+**Lesson:** Keeping routing logic in the collector decouples application changes from backend integrations.
+
+## 4. Use the LGTM Stack for Telemetry Storage
+
+1. **Prometheus** stores metrics and powers Grafana dashboards; configure scrape jobs to target the collector rather than the app to consolidate metrics exposure.【F:deploy/k8s/base/config/prometheus/prometheus.yml†L1-L8】
+2. **Tempo** ingests OTLP traces out of the box, simplifying Grafana data source configuration.【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L26-L32】
+3. **Loki** supports OTLP log ingestion, enabling trace-to-log pivots thanks to shared IDs in log payloads.【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L32-L38】【F:app/main.py†L70-L118】
+4. **Grafana** unifies visualization. Provision data sources and dashboards via configuration files for repeatable deployments (`deploy/k8s/base/config/grafana`).
+
+**Reminder:** Persist Prometheus and Loki data with volumes in production to avoid telemetry gaps after restarts.
+
+## 5. Maintain Environment Parity
+
+1. Store canonical configuration (Grafana provisioning, collector pipelines, backend configs) under `deploy/k8s/base/config/` so both Compose and Kubernetes reuse the same artifacts.
+2. Provide Compose files (`docker-compose.yml`) for local testing and Kustomize overlays (`deploy/k8s/overlays/*`) for clusters, ensuring each environment diverges only where necessary (e.g., resource limits, ingress, image pull policies).
+3. Share environment variables (`.env`) to align credentials and service endpoints across deployments.【F:README.md†L52-L85】
+
+**Outcome:** Developers can reproduce observability issues locally with confidence that production pipelines behave identically.
+
+## 6. Automate Load Generation for Testing
+
+1. Implement a lightweight traffic generator (see `loadgen/loadgen.py`) to simulate real workloads and edge cases (latency and errors).【F:loadgen/loadgen.py†L1-L25】
+2. Run the load generator in CI or during manual testing to validate dashboards, alerts, and correlations end-to-end.
+3. Capture synthetic trace IDs or request IDs in test logs to assert telemetry completeness when running automated checks.
+
+## 7. Testing and Quality Gates
+
+1. Keep application tests in `tests/` and run them as part of CI to ensure feature changes do not break primary routes.
+2. Leverage `docker-compose.integration.yml` or the Kubernetes manifests to spin up ephemeral observability stacks for smoke tests.
+3. Validate observability by querying Grafana panels, Loki log streams, and Tempo trace views after running the load generator. Treat any missing telemetry as a failing condition.
+
+## 8. Operational Considerations
+
+1. Harden Grafana credentials (`GF_SECURITY_*` settings) before exposing the stack beyond local environments.【F:README.md†L52-L85】
+2. Size the collector and backends according to expected throughput; use the `memory_limiter` processor as a safeguard and monitor queue pressure metrics for tuning.
+3. Monitor storage utilization for Prometheus and Loki; configure retention policies that align with compliance requirements.
+4. Document on-call runbooks for investigating missing telemetry—e.g., checking collector logs, verifying exporter connectivity, and ensuring OTLP endpoints are reachable.
+
+## 9. Extending the Pattern
+
+1. Add new exporters (e.g., OpenSearch for logs, Jaeger for traces) by editing `otelcol-config.yml` without touching application code.【F:deploy/k8s/base/config/otel-collector/otelcol-config.yml†L1-L38】
+2. Introduce service-level objectives by defining recording rules in Prometheus and alerting via Alertmanager.
+3. Expand tracing depth with manual spans around database calls or external API integrations.
+4. Consider tail-based sampling in the collector once trace volume grows beyond storage capacity.
+
+## 10. Documentation and Knowledge Sharing
+
+1. Maintain architecture diagrams and walkthroughs (see `docs/high-level-design.md`) so new teams understand how telemetry flows through the system.
+2. Keep lessons learned current by updating this document after major changes or incidents.
+3. Encourage contributions by linking to relevant files within the repository whenever guidance references code or configuration.
+
+By following these lessons, teams can rapidly bootstrap an observability platform that remains testable, maintainable, and extensible as the application evolves.


### PR DESCRIPTION
## Summary
- add a high-level design document with Mermaid diagrams covering system context, architecture, deployment, and request flow
- capture lessons learned and a replication guide for rebuilding the observability MVP
- refresh the README to link the new documents and summarize the architecture

## Testing
- not run (documentation-only changes)

ref: #1

------
https://chatgpt.com/codex/tasks/task_e_68d451cc2b608323b9f7d0e8f82a3918